### PR TITLE
Added a shorthand for specifying depth as the second argument

### DIFF
--- a/inspect.lua
+++ b/inspect.lua
@@ -147,6 +147,10 @@ end
 
 -------------------------------------------------------------------
 function inspect.inspect(rootObject, options)
+  if type(options) == 'number' then
+    options = {depth = options}
+  end
+
   options       = options or {}
   local depth   = options.depth or math.huge
   local filter  = parse_filter(options.filter or {})

--- a/spec/inspect_spec.lua
+++ b/spec/inspect_spec.lua
@@ -153,6 +153,28 @@ describe( 'inspect', function()
 
       end)
 
+      it('can be passed directly as second argument', function()
+        assert.equals(inspect(level5, 2), [[{ 1, 2, 3,
+  a = {
+    b = {...}
+  }
+}]])
+        assert.equals(inspect(level5, 1), [[{ 1, 2, 3,
+  a = {...}
+}]])
+        assert.equals(inspect(level5, 0), "{...}")
+        assert.equals(inspect(level5, 4), [[{ 1, 2, 3,
+  a = {
+    b = {
+      c = {
+        d = {...}
+      }
+    }
+  }
+}]])
+
+      end)
+
       it('respects depth on keys', function()
         assert.equals(inspect(keys, {depth = 4}), [[{
   [{ 1, 2, 3,


### PR DESCRIPTION
Besides retaining backwards compabibility with 1.x.x it would also be a nice shorthand (as depth is perhaps the most common option)
