### PR TITLE
Remove redundant `escapeChar` function

### DIFF
--- a/inspect.lua
+++ b/inspect.lua
@@ -45,10 +45,8 @@ local controlCharsTranslation = {
   ["\r"] = "\\r",  ["\t"] = "\\t", ["\v"] = "\\v"
 }
 
-local function escapeChar(c) return controlCharsTranslation[c] end
-
 local function escape(str)
-  local result = str:gsub("\\", "\\\\"):gsub("(%c)", escapeChar)
+  local result = str:gsub("\\", "\\\\"):gsub("(%c)", controlCharsTranslation)
   return result
 end
 


### PR DESCRIPTION
Hello! This is just a small clean-up: since `string.gsub` can accept a table as the third argument, `controlCharsTranslation` can be passed to it directly, there is no need to wrap it in a function. 
