### PR TITLE
Fix order of arguments in assertions

### DIFF
--- a/spec/inspect_spec.lua
+++ b/spec/inspect_spec.lua
@@ -6,81 +6,81 @@ describe( 'inspect', function()
 
   describe('numbers', function()
     it('works', function()
-      assert.equals(inspect(1), "1")
-      assert.equals(inspect(1.5), "1.5")
-      assert.equals(inspect(-3.14), "-3.14")
+      assert.equals("1", inspect(1))
+      assert.equals("1.5", inspect(1.5))
+      assert.equals("-3.14", inspect(-3.14))
     end)
   end)
 
   describe('strings', function()
     it('puts quotes around regular strings', function()
-      assert.equals(inspect("hello"), '"hello"')
+      assert.equals('"hello"', inspect("hello"))
     end)
 
     it('puts apostrophes around strings with quotes', function()
-      assert.equals(inspect('I have "quotes"'), "'I have \"quotes\"'")
+      assert.equals("'I have \"quotes\"'", inspect('I have "quotes"'))
     end)
 
     it('uses regular quotes if the string has both quotes and apostrophes', function()
-      assert.equals(inspect("I have \"quotes\" and 'apostrophes'"), '"I have \\"quotes\\" and \'apostrophes\'"')
+      assert.equals('"I have \\"quotes\\" and \'apostrophes\'"', inspect("I have \"quotes\" and 'apostrophes'"))
     end)
 
     it('escapes newlines properly', function()
-       assert.equals(inspect('I have \n new \n lines'), '"I have \\n new \\n lines"')
+       assert.equals('"I have \\n new \\n lines"', inspect('I have \n new \n lines'))
     end)
 
     it('escapes tabs properly', function()
-       assert.equals(inspect('I have \t a tab character'), '"I have \\t a tab character"')
+       assert.equals('"I have \\t a tab character"', inspect('I have \t a tab character'))
     end)
 
     it('escapes backspaces properly', function()
-       assert.equals(inspect('I have \b a back space'), '"I have \\b a back space"')
+       assert.equals('"I have \\b a back space"', inspect('I have \b a back space'))
     end)
 
     it('backslashes its backslashes', function()
-       assert.equals(inspect('I have \\ a backslash'), '"I have \\\\ a backslash"')
-       assert.equals(inspect('I have \\\\ two backslashes'), '"I have \\\\\\\\ two backslashes"')
-       assert.equals(inspect('I have \\\n a backslash followed by a newline'), '"I have \\\\\\n a backslash followed by a newline"')
+       assert.equals('"I have \\\\ a backslash"', inspect('I have \\ a backslash'))
+       assert.equals('"I have \\\\\\\\ two backslashes"', inspect('I have \\\\ two backslashes'))
+       assert.equals('"I have \\\\\\n a backslash followed by a newline"', inspect('I have \\\n a backslash followed by a newline'))
     end)
 
   end)
 
   it('works with nil', function()
-    assert.equals(inspect(nil), 'nil')
+    assert.equals('nil', inspect(nil))
   end)
 
   it('works with functions', function()
-    assert.equals(inspect({ print, type, print }), '{ <function 1>, <function 2>, <function 1> }')
+    assert.equals('{ <function 1>, <function 2>, <function 1> }', inspect({ print, type, print }))
   end)
 
   it('works with booleans', function()
-    assert.equals(inspect(true), 'true')
-    assert.equals(inspect(false), 'false')
+    assert.equals('true', inspect(true))
+    assert.equals('false', inspect(false))
   end)
 
   if is_luajit then
     it('works with luajit cdata', function()
-      assert.equals(inspect({ ffi.new("int", 1), ffi.typeof("int"), ffi.typeof("int")(1) }), '{ <cdata 1>, <cdata 2>, <cdata 3> }')
+      assert.equals('{ <cdata 1>, <cdata 2>, <cdata 3> }', inspect({ ffi.new("int", 1), ffi.typeof("int"), ffi.typeof("int")(1) }))
     end)
   end
 
   describe('tables', function()
 
     it('works with simple array-like tables', function()
-      assert.equals(inspect({1,2,3}), "{ 1, 2, 3 }" )
+      assert.equals("{ 1, 2, 3 }", inspect({1,2,3}))
     end)
 
     it('works with nested arrays', function()
-      assert.equals(inspect({'a','b','c', {'d','e'}, 'f'}), '{ "a", "b", "c", { "d", "e" }, "f" }' )
+      assert.equals('{ "a", "b", "c", { "d", "e" }, "f" }', inspect({'a','b','c', {'d','e'}, 'f'}))
     end)
 
     it('works with simple dictionary tables', function()
-      assert.equals(inspect({a = 1, b = 2}), "{\n  a = 1,\n  b = 2\n}")
+      assert.equals("{\n  a = 1,\n  b = 2\n}", inspect({a = 1, b = 2}))
     end)
 
     it('identifies numeric non-array keys as dictionary keys', function()
-      assert.equals(inspect({1, 2, [-1] = true}), "{ 1, 2,\n  [-1] = true\n}")
-      assert.equals(inspect({1, 2, [1.5] = true}), "{ 1, 2,\n  [1.5] = true\n}")
+      assert.equals("{ 1, 2,\n  [-1] = true\n}", inspect({1, 2, [-1] = true}))
+      assert.equals("{ 1, 2,\n  [1.5] = true\n}", inspect({1, 2, [1.5] = true}))
     end)
 
     it('sorts keys in dictionary tables', function()
@@ -89,7 +89,7 @@ describe( 'inspect', function()
         [coroutine.create(function() end)] = 1,
         [14] = 1, [{c=2}] = 1, [true]= 1
       }
-      assert.equals(inspect(t), unindent([[
+      assert.equals(unindent([[
         { 1, 2, 3,
           [14] = 1,
           [true] = 1,
@@ -101,30 +101,28 @@ describe( 'inspect', function()
           [<function 1>] = 1,
           [<thread 1>] = 1
         }
-      ]]))
+      ]]), inspect(t))
     end)
 
     it('works with nested dictionary tables', function()
-      assert.equals(inspect( {d=3, b={c=2}, a=1} ), unindent([[{
+      assert.equals(unindent([[{
         a = 1,
         b = {
           c = 2
         },
         d = 3
-      }]]))
+      }]]), inspect( {d=3, b={c=2}, a=1} ))
     end)
 
     it('works with hybrid tables', function()
-      assert.equals(
-        inspect({ 'a', {b = 1}, 2, c = 3, ['ahoy you'] = 4 }),
-        unindent([[
+      assert.equals(unindent([[
           { "a", {
             b = 1
           }, 2,
           ["ahoy you"] = 4,
           c = 3
         }
-        ]]))
+        ]]), inspect({ 'a', {b = 1}, 2, c = 3, ['ahoy you'] = 4 }))
     end)
 
     it('displays <table x> instead of repeating an already existing table', function()
@@ -133,7 +131,7 @@ describe( 'inspect', function()
       a[4] = b
       a[5] = a
       a[6] = b
-      assert.equals(inspect(a), '<1>{ 1, 2, 3, <2>{ "a", "b", "c", <table 1> }, <table 1>, <table 2> }')
+      assert.equals('<1>{ 1, 2, 3, <2>{ "a", "b", "c", <table 1> }, <table 1>, <table 2> }', inspect(a))
     end)
 
     describe('The depth parameter', function()
@@ -141,7 +139,7 @@ describe( 'inspect', function()
       local keys = { [level5] = true }
 
       it('has infinite depth by default', function()
-        assert.equals(inspect(level5), unindent([[
+        assert.equals(unindent([[
           { 1, 2, 3,
             a = {
               b = {
@@ -153,24 +151,24 @@ describe( 'inspect', function()
               }
             }
           }
-        ]]))
+        ]]), inspect(level5))
       end)
       it('is modifiable by the user', function()
-        assert.equals(inspect(level5, {depth = 2}), unindent([[
+        assert.equals(unindent([[
           { 1, 2, 3,
             a = {
               b = {...}
             }
           }
-        ]]))
+        ]]), inspect(level5, {depth = 2}))
 
-        assert.equals(inspect(level5, {depth = 1}), unindent([[
+        assert.equals(unindent([[
           { 1, 2, 3,
             a = {...}
           }
-        ]]))
+        ]]), inspect(level5, {depth = 1}))
 
-        assert.equals(inspect(level5, {depth = 4}), unindent([[
+        assert.equals(unindent([[
           { 1, 2, 3,
             a = {
               b = {
@@ -180,13 +178,13 @@ describe( 'inspect', function()
               }
             }
           }
-        ]]))
+        ]]), inspect(level5, {depth = 4}))
 
-        assert.equals(inspect(level5, {depth = 0}), "{...}")
+        assert.equals("{...}", inspect(level5, {depth = 0}))
       end)
 
       it('respects depth on keys', function()
-        assert.equals(inspect(keys, {depth = 4}), unindent([[
+        assert.equals(unindent([[
           {
             [{ 1, 2, 3,
               a = {
@@ -196,7 +194,7 @@ describe( 'inspect', function()
               }
             }] = true
           }
-        ]]))
+        ]]), inspect(keys, {depth = 4}))
       end)
     end)
 
@@ -204,7 +202,7 @@ describe( 'inspect', function()
       it('changes the substring used for newlines', function()
         local t = {a={b=1}}
 
-        assert.equal(inspect(t, {newline='@'}), "{@  a = {@    b = 1@  }@}")
+        assert.equal("{@  a = {@    b = 1@  }@}", inspect(t, {newline='@'}))
       end)
     end)
 
@@ -212,7 +210,7 @@ describe( 'inspect', function()
       it('changes the substring used for indenting', function()
         local t = {a={b=1}}
 
-        assert.equal(inspect(t, {indent='>>>'}), "{\n>>>a = {\n>>>>>>b = 1\n>>>}\n}")
+        assert.equal("{\n>>>a = {\n>>>>>>b = 1\n>>>}\n}", inspect(t, {indent='>>>'}))
       end)
     end)
 
@@ -221,56 +219,56 @@ describe( 'inspect', function()
       it('removes one element', function()
         local names     = {'Andrew', 'Peter', 'Ann' }
         local removeAnn = function(item) if item ~= 'Ann' then return item end end
-        assert.equals(inspect(names, {process = removeAnn}), '{ "Andrew", "Peter" }')
+        assert.equals('{ "Andrew", "Peter" }', inspect(names, {process = removeAnn}))
       end)
 
       it('uses the path', function()
         local names     = {'Andrew', 'Peter', 'Ann' }
         local removeThird = function(item, path) if path[1] ~= 3 then return item end end
-        assert.equals(inspect(names, {process = removeThird}), '{ "Andrew", "Peter" }')
+        assert.equals('{ "Andrew", "Peter" }', inspect(names, {process = removeThird}))
       end)
 
       it('replaces items', function()
         local names     = {'Andrew', 'Peter', 'Ann' }
         local filterAnn = function(item) return item == 'Ann' and '<filtered>' or item end
-        assert.equals(inspect(names, {process = filterAnn}), '{ "Andrew", "Peter", "<filtered>" }')
+        assert.equals('{ "Andrew", "Peter", "<filtered>" }', inspect(names, {process = filterAnn}))
       end)
 
       it('nullifies metatables', function()
         local mt       = {'world'}
         local t        = setmetatable({'hello'}, mt)
         local removeMt = function(item) if item ~= mt then return item end end
-        assert.equals(inspect(t, {process = removeMt}), '{ "hello" }')
+        assert.equals('{ "hello" }', inspect(t, {process = removeMt}))
       end)
 
       it('nullifies metatables using their paths', function()
         local mt       = {'world'}
         local t        = setmetatable({'hello'}, mt)
         local removeMt = function(item, path) if path[#path] ~= inspect.METATABLE then return item end end
-        assert.equals(inspect(t, {process = removeMt}), '{ "hello" }')
+        assert.equals('{ "hello" }', inspect(t, {process = removeMt}))
       end)
 
       it('nullifies the root object', function()
         local names     = {'Andrew', 'Peter', 'Ann' }
         local removeNames = function(item) if item ~= names then return item end end
-        assert.equals(inspect(names, {process = removeNames}), 'nil')
+        assert.equals('nil', inspect(names, {process = removeNames}))
       end)
 
       it('changes keys', function()
         local dict = {a = 1}
         local changeKey = function(item) return item == 'a' and 'x' or item end
-        assert.equals(inspect(dict, {process = changeKey}), '{\n  x = 1\n}')
+        assert.equals('{\n  x = 1\n}', inspect(dict, {process = changeKey}))
       end)
 
       it('nullifies keys', function()
         local dict = {a = 1, b = 2}
         local removeA = function(item) return item ~= 'a' and item or nil end
-        assert.equals(inspect(dict, {process = removeA}), '{\n  b = 2\n}')
+        assert.equals('{\n  b = 2\n}', inspect(dict, {process = removeA}))
       end)
 
       it('prints inspect.KEY & inspect.METATABLE', function()
         local t = {inspect.KEY, inspect.METATABLE}
-        assert.equals(inspect(t), "{ inspect.KEY, inspect.METATABLE }")
+        assert.equals("{ inspect.KEY, inspect.METATABLE }", inspect(t))
       end)
 
       it('marks key paths with inspect.KEY and metatables with inspect.METATABLE', function()
@@ -284,7 +282,7 @@ describe( 'inspect', function()
 
         inspect(t, {process = addItem})
 
-        assert.same(items, {
+        assert.same({
           {item = t,                           path = {}},
           {item = {a=1},                       path = {{a=1}, inspect.KEY}},
           {item = 'a',                         path = {{a=1}, inspect.KEY, 'a', inspect.KEY}},
@@ -295,7 +293,7 @@ describe( 'inspect', function()
           {item = {c=3},                       path = {{a=1}, inspect.METATABLE}},
           {item = 'c',                         path = {{a=1}, inspect.METATABLE, 'c', inspect.KEY}},
           {item = 3,                           path = {{a=1}, inspect.METATABLE, 'c'}}
-        })
+        }, items)
 
       end)
     end)
@@ -305,7 +303,7 @@ describe( 'inspect', function()
       it('includes the metatable as an extra hash attribute', function()
         local foo = { foo = 1, __mode = 'v' }
         local bar = setmetatable({a = 1}, foo)
-        assert.equals(inspect(bar), unindent([[
+        assert.equals(unindent([[
           {
             a = 1,
             <metatable> = {
@@ -313,13 +311,13 @@ describe( 'inspect', function()
               foo = 1
             }
           }
-        ]]))
+        ]]), inspect(bar))
       end)
 
       it('includes the __tostring metamethod if it exists', function()
         local foo = { foo = 1, __tostring = function() return 'hello\nworld' end }
         local bar = setmetatable({a = 1}, foo)
-        assert.equals(inspect(bar), unindent([[
+        assert.equals(unindent([[
           { -- hello\nworld
             a = 1,
             <metatable> = {
@@ -327,13 +325,13 @@ describe( 'inspect', function()
               foo = 1
             }
           }
-        ]]))
+        ]]), inspect(bar))
       end)
 
       it('includes an error string if __tostring metamethod throws an error', function()
         local foo = { foo = 1, __tostring = function() error('hello', 0) end }
         local bar = setmetatable({a = 1}, foo)
-        assert.equals(inspect(bar), unindent([[
+        assert.equals(unindent([[
           { -- error: hello
             a = 1,
             <metatable> = {
@@ -341,30 +339,30 @@ describe( 'inspect', function()
               foo = 1
             }
           }
-        ]]))
+        ]]), inspect(bar))
       end)
 
       describe('When a table is its own metatable', function()
         it('accepts a table that is its own metatable without stack overflowing', function()
           local x = {}
           setmetatable(x,x)
-          assert.equals(inspect(x), unindent([[
+          assert.equals(unindent([[
             <1>{
               <metatable> = <table 1>
             }
-          ]]))
+          ]]), inspect(x))
         end)
 
         it('can invoke the __tostring method without stack overflowing', function()
           local t = {}
           t.__index = t
           setmetatable(t,t)
-          assert.equals(inspect(t), unindent([[
+          assert.equals(unindent([[
             <1>{
               __index = <table 1>,
               <metatable> = <table 1>
             }
-          ]]))
+          ]]), inspect(t))
         end)
       end)
     end)


### PR DESCRIPTION
luassert assertions like `assert.equals` and `assert.same` take expected value as the first argument and actual result as the second one. Currently the order is reversed, which makes failure reports confusing. This should fix the problem. 
