### PR TITLE
Store used external function in local scope

### DIFF
--- a/inspect.lua
+++ b/inspect.lua
@@ -28,6 +28,17 @@ local inspect ={
   ]]
 }
 
+local pairs = pairs
+local ipairs = ipairs
+local type = type
+local math = math
+local tostring = tostring
+local rawset = rawset
+local next = next
+local getmetatable = getmetatable
+local table = table
+local setmetatable = setmetatable
+
 inspect.KEY       = setmetatable({}, {__tostring = function() return 'inspect.KEY' end})
 inspect.METATABLE = setmetatable({}, {__tostring = function() return 'inspect.METATABLE' end})
 


### PR DESCRIPTION
Fix bug like this:
function fn(...) setmetatable = {...} return setmetatable end
print(inspect(fn(1,2,3))) -- error, attempt to call a table value (global 'setmetatable')