### PR TITLE
avoid __len metamethod

### DIFF
--- a/inspect.lua
+++ b/inspect.lua
@@ -84,7 +84,7 @@ local function sortKeys(a, b)
 end
 
 local function getNonSequentialKeys(t)
-  local keys, length = {}, #t
+  local keys, length = {}, rawlen(t)
   for k,_ in pairs(t) do
     if not isSequenceKey(k, length) then table.insert(keys, k) end
   end
@@ -232,7 +232,7 @@ function Inspector:putTable(t)
     if self.tableAppearances[t] > 1 then self:puts('<', self:getId(t), '>') end
 
     local nonSequentialKeys = getNonSequentialKeys(t)
-    local length            = #t
+    local length            = rawlen(t)
     local mt                = getmetatable(t)
     local toStringResult    = getToStringResultSafely(t, mt)
 

--- a/inspect.lua
+++ b/inspect.lua
@@ -31,6 +31,19 @@ local inspect ={
 inspect.KEY       = setmetatable({}, {__tostring = function() return 'inspect.KEY' end})
 inspect.METATABLE = setmetatable({}, {__tostring = function() return 'inspect.METATABLE' end})
 
+local rawlen = rawlen or function(t)
+  local _M, len = getmetatable(t)
+  if _M then
+    setmetatable(t, {})
+    len = #t
+    setmetatable(t, _M)
+  else
+    len = #t
+  end
+
+  return len
+end
+
 -- Apostrophizes the string if it has quotes, but not aphostrophes
 -- Otherwise, it returns a regular quoted string
 local function smartQuote(str)

--- a/inspect.lua
+++ b/inspect.lua
@@ -32,16 +32,7 @@ inspect.KEY       = setmetatable({}, {__tostring = function() return 'inspect.KE
 inspect.METATABLE = setmetatable({}, {__tostring = function() return 'inspect.METATABLE' end})
 
 local rawlen = rawlen or function(t)
-  local _M, len = getmetatable(t)
-  if _M then
-    setmetatable(t, {})
-    len = #t
-    setmetatable(t, _M)
-  else
-    len = #t
-  end
-
-  return len
+  return #t
 end
 
 -- Apostrophizes the string if it has quotes, but not aphostrophes


### PR DESCRIPTION
I found the problem that inspect sometimes uses `#` operator to user defined table. If the table has `__len` metamethod, the function is called and an unexpected thing occur. To avoid this problem, you should use `rawlen`.