### PR TITLE
fix problem with escaping zero and other control characters

### DIFF
--- a/inspect.lua
+++ b/inspect.lua
@@ -41,17 +41,22 @@ local function smartQuote(str)
 end
 
 local controlCharsTranslation = {
-  ["\\7"]   = "\\a",  ["\\007"] = "\\a",  
-  ["\\8"]   = "\\b",  ["\\008"] = "\\b", 
-  ["\\12"]  = "\\f",  ["\\012"] = "\\f", 
-  ["\\13"]  = "\\r",  ["\\013"] = "\\r",  
-  ["\\9"]   = "\\t",  ["\\009"] = "\\t", 
-  ["\\11"]  = "\\v",  ["\\011"] = "\\v",
+  ["\a"] = "\\a",  ["\b"] = "\\b", ["\f"] = "\\f",  ["\n"] = "\\n",
+  ["\r"] = "\\r",  ["\t"] = "\\t", ["\v"] = "\\v"
 }
 
+local controlCharsTranslationBeforeDigit = {}
+
+for i=0, 31 do
+    local ch = string.char(i)
+    if not controlCharsTranslation[ch] then
+        controlCharsTranslation[ch] = "\\"..i
+        controlCharsTranslationBeforeDigit[ch] = string.format("\\%03d",i)
+    end
+end
+
 local function escape(str)
-  local f = string.format("%q", str)
-  local result = f:gsub("\\%d%d?%d?", controlCharsTranslation):gsub("\\\n", "\\n"):gsub('\\"', '"'):sub(2,-2)
+  local result = str:gsub("\\", "\\\\"):gsub("(%c)%f[0-9]", controlCharsTranslationBeforeDigit):gsub("(%c)", controlCharsTranslation)
   return result
 end
 

--- a/inspect.lua
+++ b/inspect.lua
@@ -41,12 +41,17 @@ local function smartQuote(str)
 end
 
 local controlCharsTranslation = {
-  ["\a"] = "\\a",  ["\b"] = "\\b", ["\f"] = "\\f",  ["\n"] = "\\n",
-  ["\r"] = "\\r",  ["\t"] = "\\t", ["\v"] = "\\v"
+  ["\\7"]   = "\\a",  ["\\007"] = "\\a",  
+  ["\\8"]   = "\\b",  ["\\008"] = "\\b", 
+  ["\\12"]  = "\\f",  ["\\012"] = "\\f", 
+  ["\\13"]  = "\\r",  ["\\013"] = "\\r",  
+  ["\\9"]   = "\\t",  ["\\009"] = "\\t", 
+  ["\\11"]  = "\\v",  ["\\011"] = "\\v",
 }
 
 local function escape(str)
-  local result = str:gsub("\\", "\\\\"):gsub("(%c)", controlCharsTranslation)
+  local f = string.format("%q", str)
+  local result = f:gsub("\\%d%d?%d?", controlCharsTranslation):gsub("\\\n", "\\n"):gsub('\\"', '"'):sub(2,-2)
   return result
 end
 

--- a/spec/inspect_spec.lua
+++ b/spec/inspect_spec.lua
@@ -39,8 +39,8 @@ describe( 'inspect', function()
     end)
 
     it('escapes zeroes and other control characters properly', function()
-       assert.equals('"I have \\0 zeroes \\0000 and other \\1 control \\0010 characters"', 
-              inspect('I have \0 zeroes \0000 and other \1 control \0010 characters'))
+       assert.equals('"I have \\0 zeroes \\0000 and other \\1 control \\0010 characters \\6 \\17 \\0279 \\31"', 
+              inspect('I have \0 zeroes \0000 and other \1 control \0010 characters \6 \17 \0279 \31'))
     end)
 
     it('backslashes its backslashes', function()

--- a/spec/inspect_spec.lua
+++ b/spec/inspect_spec.lua
@@ -38,6 +38,11 @@ describe( 'inspect', function()
        assert.equals('"I have \\b a back space"', inspect('I have \b a back space'))
     end)
 
+    it('escapes zeroes and other control characters properly', function()
+       assert.equals('"I have \\0 zeroes \\0000 and other \\1 control \\0010 characters"', 
+              inspect('I have \0 zeroes \0000 and other \1 control \0010 characters'))
+    end)
+
     it('backslashes its backslashes', function()
        assert.equals('"I have \\\\ a backslash"', inspect('I have \\ a backslash'))
        assert.equals('"I have \\\\\\\\ two backslashes"', inspect('I have \\\\ two backslashes'))


### PR DESCRIPTION
Hello Enrico,

First of all, thank you for having created the inspect module. It is of great use for me.

Here I have a fix for a bug that shows up when you have zero characters in the string.

Best regards 
Andreas Hofer