### PR TITLE
fix endless recursion when using inspect to reimplement global tostring

### DIFF
--- a/inspect.lua
+++ b/inspect.lua
@@ -28,7 +28,7 @@ local inspect ={
   ]]
 }
 
-inspect.tostring = _G.tostring
+local tostring = tostring
 
 inspect.KEY       = setmetatable({}, {__tostring = function() return 'inspect.KEY' end})
 inspect.METATABLE = setmetatable({}, {__tostring = function() return 'inspect.METATABLE' end})
@@ -112,7 +112,7 @@ local function getToStringResultSafely(t, mt)
   local str, ok
   if type(__tostring) == 'function' then
     ok, str = pcall(__tostring, t)
-    str = ok and str or 'error: ' .. inspect.tostring(str)
+    str = ok and str or 'error: ' .. tostring(str)
   end
   if type(str) == 'string' and #str > 0 then return str end
 end
@@ -226,7 +226,7 @@ function Inspector:getId(v)
     self.maxIds[tv] = id
     self.ids[tv][v] = id
   end
-  return inspect.tostring(id)
+  return tostring(id)
 end
 
 function Inspector:putKey(k)
@@ -238,7 +238,7 @@ end
 
 function Inspector:putTable(t)
   if t == inspect.KEY or t == inspect.METATABLE then
-    self:puts(inspect.tostring(t))
+    self:puts(tostring(t))
   elseif self:alreadyVisited(t) then
     self:puts('<table ', self:getId(t), '>')
   elseif self.level >= self.depth then
@@ -298,7 +298,7 @@ function Inspector:putValue(v)
   if tv == 'string' then
     self:puts(smartQuote(escape(v)))
   elseif tv == 'number' or tv == 'boolean' or tv == 'nil' then
-    self:puts(inspect.tostring(v))
+    self:puts(tostring(v))
   elseif tv == 'table' then
     self:putTable(v)
   else

--- a/inspect.lua
+++ b/inspect.lua
@@ -28,6 +28,8 @@ local inspect ={
   ]]
 }
 
+inspect.tostring = _G.tostring
+
 inspect.KEY       = setmetatable({}, {__tostring = function() return 'inspect.KEY' end})
 inspect.METATABLE = setmetatable({}, {__tostring = function() return 'inspect.METATABLE' end})
 
@@ -110,7 +112,7 @@ local function getToStringResultSafely(t, mt)
   local str, ok
   if type(__tostring) == 'function' then
     ok, str = pcall(__tostring, t)
-    str = ok and str or 'error: ' .. tostring(str)
+    str = ok and str or 'error: ' .. inspect.tostring(str)
   end
   if type(str) == 'string' and #str > 0 then return str end
 end
@@ -198,7 +200,7 @@ function Inspector:puts(...)
   local len    = #buffer
   for i=1, #args do
     len = len + 1
-    buffer[len] = tostring(args[i])
+    buffer[len] = args[i]
   end
 end
 
@@ -224,7 +226,7 @@ function Inspector:getId(v)
     self.maxIds[tv] = id
     self.ids[tv][v] = id
   end
-  return id
+  return inspect.tostring(id)
 end
 
 function Inspector:putKey(k)
@@ -236,7 +238,7 @@ end
 
 function Inspector:putTable(t)
   if t == inspect.KEY or t == inspect.METATABLE then
-    self:puts(tostring(t))
+    self:puts(inspect.tostring(t))
   elseif self:alreadyVisited(t) then
     self:puts('<table ', self:getId(t), '>')
   elseif self.level >= self.depth then
@@ -296,7 +298,7 @@ function Inspector:putValue(v)
   if tv == 'string' then
     self:puts(smartQuote(escape(v)))
   elseif tv == 'number' or tv == 'boolean' or tv == 'nil' then
-    self:puts(tostring(v))
+    self:puts(inspect.tostring(v))
   elseif tv == 'table' then
     self:putTable(v)
   else

--- a/spec/inspect_spec.lua
+++ b/spec/inspect_spec.lua
@@ -414,9 +414,7 @@ describe( 'inspect', function()
 
   it('allows changing the global tostring', function()
     local save = _G.tostring
-    _G.tostring = function(x) 
-                      return inspect(x) 
-                  end
+    _G.tostring = inspect 
     local s = tostring({1, 2, 3})
     _G.tostring = save    
     assert.equals("{ 1, 2, 3 }", s)

--- a/spec/inspect_spec.lua
+++ b/spec/inspect_spec.lua
@@ -415,11 +415,7 @@ describe( 'inspect', function()
   it('allows changing the global tostring', function()
     local save = _G.tostring
     _G.tostring = function(x) 
-                    if type(x) == "string" then 
-                      return x 
-                    else 
                       return inspect(x) 
-                    end 
                   end
     local s = tostring({1, 2, 3})
     _G.tostring = save    

--- a/spec/inspect_spec.lua
+++ b/spec/inspect_spec.lua
@@ -411,4 +411,19 @@ describe( 'inspect', function()
       end)
     end)
   end)
+
+  it('allows changing the global tostring', function()
+    local save = _G.tostring
+    _G.tostring = function(x) 
+                    if type(x) == "string" then 
+                      return x 
+                    else 
+                      return inspect(x) 
+                    end 
+                  end
+    local s = tostring({1, 2, 3})
+    _G.tostring = save    
+    assert.equals("{ 1, 2, 3 }", s)
+  end) 
+
 end)


### PR DESCRIPTION
Hello Enrico,

Here I suggest a modificition that allowed me to change the global 'tostring' in Lua to make use of inspect, so that tables are displayed more usefully everywhere, like in Python. With the original version of inspect, this would cause endless recursions. Merge that one only if you like.

Best regards 
Andreas Hofer