### PR TITLE
Support LuaJIT cdata and ctype values in Inspector:putValue().

### DIFF
--- a/inspect.lua
+++ b/inspect.lua
@@ -296,7 +296,8 @@ function Inspector:putValue(v)
 
   if tv == 'string' then
     self:puts(smartQuote(escape(v)))
-  elseif tv == 'number' or tv == 'boolean' or tv == 'nil' then
+  elseif tv == 'number' or tv == 'boolean' or tv == 'nil' or
+         tv == 'cdata' or tv == 'ctype' then
     self:puts(tostring(v))
   elseif tv == 'table' then
     self:putTable(v)

--- a/spec/inspect_spec.lua
+++ b/spec/inspect_spec.lua
@@ -71,7 +71,8 @@ describe( 'inspect', function()
 
   if is_luajit then
     it('works with luajit cdata', function()
-      assert.equals('{ <cdata 1>, <cdata 2>, <cdata 3> }', inspect({ ffi.new("int", 1), ffi.typeof("int"), ffi.typeof("int")(1) }))
+      assert.equals('{ cdata<int>: PTR, ctype<int>, cdata<int>: PTR }',
+                    inspect({ ffi.new("int", 1), ffi.typeof("int"), ffi.typeof("int")(1) }):gsub('(0x%x+)','PTR'))
     end)
   end
 


### PR DESCRIPTION
Add special handling for cdata and ctype types provided by LuaJIT: use
tostring() to print values of those types, which either provides a more
meaningful default type description (e.g. 'ctype<uint64_t>' instead of
'<ctype 1>') or a user-defined value as described at
http://luajit.org/ext_ffi_api.html#tostring