### PR TITLE
ignore metatables with __metatable field set to non-nil non-table values

### DIFF
--- a/inspect.lua
+++ b/inspect.lua
@@ -180,6 +180,7 @@ local function processRecursive(process, item, path, visited)
       end
 
       local mt  = processRecursive(process, getmetatable(processed), makePath(path, inspect.METATABLE), visited)
+      if type(mt) ~= 'table' then mt = nil end -- ignore not nil/table __metatable field
       setmetatable(processedCopy, mt)
       processed = processedCopy
     end
@@ -273,7 +274,7 @@ function Inspector:putTable(t)
         count = count + 1
       end
 
-      if mt then
+      if type(mt) == 'table' then
         if count > 0 then self:puts(',') end
         self:tabify()
         self:puts('<metatable> = ')
@@ -281,7 +282,7 @@ function Inspector:putTable(t)
       end
     end)
 
-    if #nonSequentialKeys > 0 or mt then -- result is multi-lined. Justify closing }
+    if #nonSequentialKeys > 0 or type(mt) == 'table' then -- result is multi-lined. Justify closing }
       self:tabify()
     elseif sequenceLength > 0 then -- array tables have one extra space before closing }
       self:puts(' ')

--- a/spec/inspect_spec.lua
+++ b/spec/inspect_spec.lua
@@ -404,6 +404,30 @@ describe( 'inspect', function()
         ]]), inspect(t))
       end)
 
+      it('ignores metatables with __metatable field set to non-nil and non-table type', function()
+        local function process(item) return item end
+        local function inspector(data) return inspect(data, {process=process}) end
+
+        local foo = setmetatable({}, {__metatable=false})
+        local bar = setmetatable({}, {__metatable=true})
+        local baz = setmetatable({}, {__metatable=10})
+        local spam = setmetatable({}, {__metatable=nil})
+        local eggs = setmetatable({}, {__metatable={}})
+        assert.equals(unindent('{}'), inspector(foo))
+        assert.equals(unindent('{}'), inspector(bar))
+        assert.equals(unindent('{}'), inspector(baz))
+        assert.equals(unindent([[
+          {
+            <metatable> = {}
+          }
+        ]]), inspector(spam))
+        assert.equals(unindent([[
+          {
+            <metatable> = {}
+          }
+        ]]), inspector(eggs))
+      end)
+
       describe('When a table is its own metatable', function()
         it('accepts a table that is its own metatable without stack overflowing', function()
           local x = {}


### PR DESCRIPTION
Fixes and tests, as requested. Tested on lua51. Fixes #35 