### PR TITLE
Added line prefixing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ assert(inspect(t5, {depth = 2}) == [[{
 
 `options.depth` defaults to infinite (`math.huge`).
 
-#### options.newline & options.indent
+#### options.newline, options.indent and options.prefix
 
-These are the strings used by `inspect` to respectively add a newline and indent each level of a table.
+These are the strings used by `inspect` to respectively add a newline, indent each level of a table, and prefix lines.
 
-By default, `options.newline` is `"\n"` and `options.indent` is `"  "` (two spaces).
+By default, `options.newline` is `"\n"`, `options.indent` is `"  "` (two spaces) and `options.prefix` is `""` (an empty string).
 
 ``` lua
 local t = {a={b=1}}
@@ -141,7 +141,10 @@ assert(inspect(t) == [[{
   }
 }]])
 
-assert(inspect(t, {newline='@', indent="++"}), "{@++a = {@++++b = 1@++}@}"
+assert(inspect(t, {newline='@', indent="++"}), "{@++a = {@++++b = 1@++}@}")
+
+assert(inspect(t, {newline='', indent='', prefix=' '}), "{ a = { b = 1 } }")
+
 ```
 
 #### options.process
@@ -246,8 +249,3 @@ Change log
 ==========
 
 Read it on the CHANGELOG.md file
-
-
-
-
-

--- a/inspect.lua
+++ b/inspect.lua
@@ -207,7 +207,7 @@ function Inspector:down(f)
 end
 
 function Inspector:tabify()
-  self:puts(self.newline, string.rep(self.indent, self.level))
+  self:puts(self.newline, self.prefix..string.rep(self.indent, self.level))
 end
 
 function Inspector:alreadyVisited(v)
@@ -306,6 +306,7 @@ function inspect.inspect(root, options)
   local depth   = options.depth   or math.huge
   local newline = options.newline or '\n'
   local indent  = options.indent  or '  '
+  local prefix  = options.prefix  or ''
   local process = options.process
 
   if process then
@@ -320,6 +321,7 @@ function inspect.inspect(root, options)
     maxIds           = {},
     newline          = newline,
     indent           = indent,
+    prefix           = prefix,
     tableAppearances = countTableAppearances(root)
   }, Inspector_mt)
 
@@ -331,4 +333,3 @@ end
 setmetatable(inspect, { __call = function(_, ...) return inspect.inspect(...) end })
 
 return inspect
-

--- a/spec/inspect_spec.lua
+++ b/spec/inspect_spec.lua
@@ -257,6 +257,22 @@ describe( 'inspect', function()
       end)
     end)
 
+	describe('the prefix option', function()
+      it('changes the line prefix', function()
+        local t = {a={b=1}}
+
+        assert.equal(unindent([[
+          {
+          @  a = {
+          @    b = 1
+          @  }
+          @}
+        ]]), inspect(t, {prefix='@'}))
+
+		assert.equal("{ a = { b = 1 } }", inspect(t, {newline='', indent='', prefix=' '}))
+      end)
+	end)
+
     describe('the process option', function()
 
       it('removes one element', function()


### PR DESCRIPTION
Added a line prefixing options, `options.prefix`, which prefixes all but the first line output.

E.g.

    lua> t = { a = { b = 1 } }
    lua> print( inspect( t, { newline = '', indent = '', prefix = ' ' ) )
    { a = { b = 1 } }
    lua> print( '> '..inspect( t, { prefix = '> ' } )
    > {
    >   a = {
    >     b = 1
    >   }
    > }

Also updated docs and tests