### PR TITLE
stop/start inspection and direct print options

### DIFF
--- a/inspect.lua
+++ b/inspect.lua
@@ -1,4 +1,4 @@
-local inspect ={
+local inspect = {
   _VERSION = 'inspect.lua 3.1.0',
   _URL     = 'http://github.com/kikito/inspect.lua',
   _DESCRIPTION = 'human-readable representations of tables',
@@ -29,6 +29,8 @@ local inspect ={
 }
 
 local tostring = tostring
+
+inspect.waiting = true
 
 inspect.KEY       = setmetatable({}, {__tostring = function() return 'inspect.KEY' end})
 inspect.METATABLE = setmetatable({}, {__tostring = function() return 'inspect.METATABLE' end})
@@ -307,6 +309,19 @@ function inspect.inspect(root, options)
   local newline = options.newline or '\n'
   local indent  = options.indent  or '  '
   local process = options.process
+  local doprint = options.doprint or nil
+
+  if options.start then
+    inspect.waiting = false
+    return "inspect enabled"
+  end
+  if options.stop then
+    inspect.waiting = true
+    return "inspect disabled"
+  end
+  if options.wait then
+    if inspect.waiting then return "did not inspect - waiting for a start" end
+  end
 
   if process then
     root = processRecursive(process, root, {}, {})
@@ -325,10 +340,15 @@ function inspect.inspect(root, options)
 
   inspector:putValue(root)
 
-  return table.concat(inspector.buffer)
+  if doprint then
+    if doprint ~= "" then print(doprint) end
+    print(table.concat(inspector.buffer))
+    return ""
+  else
+    return table.concat(inspector.buffer)
+  end
 end
 
 setmetatable(inspect, { __call = function(_, ...) return inspect.inspect(...) end })
 
 return inspect
-

--- a/inspect.lua
+++ b/inspect.lua
@@ -309,7 +309,7 @@ function inspect.inspect(root, options)
   local newline = options.newline or '\n'
   local indent  = options.indent  or '  '
   local process = options.process
-  local doprint = options.doprint or nil
+  local doprint = options.doprint
 
   if options.start then
     inspect.waiting = false
@@ -320,7 +320,7 @@ function inspect.inspect(root, options)
     return "inspect disabled"
   end
   if options.wait then
-    if inspect.waiting then return "did not inspect - waiting for a start" end
+    if inspect.waiting then return "did not inspect - waiting for start" end
   end
 
   if process then


### PR DESCRIPTION
Keep / discard / improve - Just sharing if you are interested...

  1. Allows the inspect to wait until needed
  2. Print (with user set text) rather than return

Test...

  -- Variables
  local extensions = {"png", "bmp", {["jpg"] = 1, ["jpeg"] = 2}}

  -- Code
  print(inspect(extensions))                                                                         -- "A"
  print(inspect(extensions, {wait = true}))                                                          -- "B"
  print("C: Inspecting 'extensions': " .. inspect(extensions))                                       -- "C"
  print(inspect(extensions, {start = true}))                                                         -- "D"
  print("E: Inspecting 'extensions': " .. inspect(extensions, {wait = true}))                        -- "E"
  inspect(extensions, {wait = true, doprint = "F: Inspecting 'extensions'..."})                      -- "F"
  inspect(extensions, {wait = true, doprint = "" })                                                  -- "G"
  inspect({},{stop = true})                                                                          -- "H"
  inspect( extensions, {wait = true, doprint = "I: This should not inspect"})                        -- "I"
  for i=1,4 do                                                                                       -- "J"
      if i == 3 then inspect(_,{start = 1}) else inspect(_,{stop = 1}) end                           -- "K"
      inspect( extensions, {wait = true, doprint = "L: Inspecting 'extensions' (" .. i .. ")..." } ) -- "L"
  end

Output...

  { "png", "bmp", {
      jpeg = 2,
      jpg = 1
    } }
  did not inspect - waiting for a start
  C: Inspecting 'extensions': { "png", "bmp", {
      jpeg = 2,
      jpg = 1
    } }
  inspect enabled
  E: Inspecting 'extensions': { "png", "bmp", {
      jpeg = 2,
      jpg = 1
    } }
  F: Inspecting 'extensions'...
  { "png", "bmp", {
      jpeg = 2,
      jpg = 1
    } }
  { "png", "bmp", {
      jpeg = 2,
      jpg = 1
    } }
  L: Inspecting 'extensions' (3)...
  { "png", "bmp", {
      jpeg = 2,
      jpg = 1
    } }

Commentary...

  A: Original way still works
  B: Will only work when called after a call with start=true [note: status message added when using the original way]
  C: Original way still works [only usage with wait enabled can get blocked]
  D: Enable all subsequent wait enabled calls [Does not inspect the element / bonus status message when using the original way]
  E: Basically the same as 'C' but it will now work because a start has been done [unlike 'B' which was blocke]
  F: Basically the same as 'E' but using the new doprint option
  G: Basically the same as 'E' but using the new doprint option with no preamble
  H: Stop further inspections [absolutely nothing prints as opposed to 'D']
  I: Inspection blocked just like 'B' [but absolutely nothing prints unlike 'B']
  J: One situation where the new options can really help follows...
  K: Start and stop selectively [using simplest option settings with absolutely nothing printing]
  L: Thanks to 'K' it only inspects the chosen instance [3] !!!

Notes...

  1. As shown in 'G' and 'K', all new options only need to exist and not be nil or false (ie: Can even be 1 or "")
  2. BONUS = Can start & stop inspection in one file from another!

PS...

  Thanks for sharing the original!