### PR TITLE
Improve output of userdata, handling`__tostring` and NULL

### DIFF
--- a/inspect.lua
+++ b/inspect.lua
@@ -309,9 +309,16 @@ function Inspector:putValue(v)
   elseif tv == 'userdata' then
     local mt = getmetatable(v)
     local toStringResult = mt and getToStringResultSafely(v, mt)
-    self:puts('<', tv, ' ', self:getId(v), '>')
     if toStringResult then
+      self:puts('<userdata ', self:getId(v), '>')
       self:puts(' -- ', escape(toStringResult))
+    else
+      local str = tostring(v)
+      if str == "userdata: NULL" then
+        self:puts('<userdata NULL>')
+      else
+        self:puts('<userdata ', self:getId(v), '>')
+      end
     end
   else
     self:puts('<', tv, ' ', self:getId(v), '>')

--- a/spec/inspect_spec.lua
+++ b/spec/inspect_spec.lua
@@ -363,6 +363,17 @@ describe( 'inspect', function()
         ]]), inspect(bar))
       end)
 
+      it('includes the __tostring metamethod of userdata', function()
+        local tbl = {
+          f = io.tmpfile(),
+        }
+        assert.equals(unindent([[
+          {
+            f = <userdata 1> -- $FILE
+          }
+        ]]):gsub("$FILE", tostring(tbl.f)), inspect(tbl))
+      end)
+
       it('can be used on the __tostring metamethod of a table without errors', function()
         local f = function(x) return inspect(x) end
         local tbl = setmetatable({ x = 1 }, { __tostring = f })


### PR DESCRIPTION
This PR includes 2 commits:

The first one includes evaluation of `__tostring` for userdata values. This should be safe because `__tostring` of userdata is unlikely to recurse into `inspect`. A test is included.

The second one adds a special case for NULL userdata.

When interpreting userdata values using 'inspect', the numeric identifiers
are useful to match identify of pointers (comparing the low counters
like `<userdata 3> is easier than reading long pointers like
`userdata: 0x749abc39efa29`).

However, the `NULL` pointer is enough of a special case that it is
important to know when one of those numbered pointers happens to
be `NULL`. When one is dealing with things like JSON parsers, where
the only usual userdata is `cjson.null`, one gets accostumed over
time to interpret `<userdata 1>` to mean `NULL`. This is not obvious,
however, and a seasoned user will trip up the day another userdata
is used in the same table and `NULL` is now `<userdata 2>`.

Adding a test for this would require compiling and loading a C extension, such as `lua-cjson`. I can do so if desired.