### PR TITLE
Add `multiline` to options parameter

### DIFF
--- a/spec/inspect_spec.lua
+++ b/spec/inspect_spec.lua
@@ -257,6 +257,53 @@ describe( 'inspect', function()
       end)
     end)
 
+    describe('the multiline option', function()
+      it('sets a table on a singe line when `false`', function()
+        local t = { 
+          a= {1,2}
+        }
+        assert.equals("{ a = { 1, 2 } }", inspect(t, {multiline=false}))
+      end)
+
+      it('sets each table value on its own line when `true`', function()
+        local t = { 
+          a= {1,2}
+        }
+        assert.equals(unindent([[
+          {
+            a = {
+              1,
+              2
+            }
+          }
+        ]]), inspect(t, {multiline=true}))
+      end)
+      
+      it('allows users to specify a predicate function for determining new-line behavior', function()
+        local t = {
+          {
+            name = 'Link',
+            color = 'green'
+          },
+          {
+            name = 'Zelda',
+            color = 'blue'
+          }
+        }
+        local options = {
+          multiline = function(t, k) 
+            return type(k) == 'number' and type(t[k]) == 'table'
+          end
+        }
+        assert.equals(unindent([[
+          {
+            { color = "green", name = "Link" },
+            { color = "blue", name = "Zelda" }
+          }
+        ]]), inspect(t, options))
+      end)
+    end)
+
     describe('the process option', function()
 
       it('removes one element', function()


### PR DESCRIPTION
## Problem
As raised in #31, there are some readability issues when stringifying nested tables.

This is an example of how we were using `inspect` for our code docs on Zelda Wiki. 
![image](https://user-images.githubusercontent.com/7321311/76632874-43d7e980-651a-11ea-88eb-ebc9b841f55a.png) 
 
## Solution in this PR
Adding `options.multiline`, a predicate function telling `inspect` how to print lines for tables. For example,
```lua
local hasNestedTables = function(tt) [...] end
inspect(tt, {
  multiline = hasNestedTables
})
```

As of now Zelda Wiki is using this fork. You can see our predicate function on line 8 of [this module](https://zelda.gamepedia.com/index.php?title=Module:UtilsTable&action=edit).

| Before | After |
| ------- | ----- |
| ![image](https://user-images.githubusercontent.com/7321311/76635188-733c2580-651d-11ea-8897-92031d1f6688.png) | ![image](https://user-images.githubusercontent.com/7321311/76635151-63bcdc80-651d-11ea-9065-2c2dcf908426.png) |

### Bonus
Something that comes for free with this is,
```lua
inspect(tt, { multiline = false }
```
which dumps everything on one line, and
```lua
inspect(tt, { multiline = true }
```
which prints every table element on its own line. 


