### PR TITLE
Introduce perf test harness and refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+.PHONY: all dev gen check test perf
+
+LUA := $(shell luarocks config lua_interpreter)
+
 all: gen check test
 
 dev:
@@ -13,6 +17,9 @@ check:
 
 test:
 	busted
+
+perf:
+	$(shell luarocks config lua_interpreter) perf.lua
 
 
 

--- a/inspect.lua
+++ b/inspect.lua
@@ -255,10 +255,6 @@ function Inspector:getId(v)
    return tostring(id)
 end
 
-
-function Inspector:putValue(_)
-end
-
 function Inspector:putKey(k)
    if isIdentifier(k) then
       self:puts(k)

--- a/inspect.lua
+++ b/inspect.lua
@@ -279,32 +279,34 @@ function Inspector:putTable(t)
       local mt = getmetatable(t)
 
       self:puts('{')
-      self:down(function()
-         local count = 0
-         for i = 1, sequenceLength do
-            if count > 0 then self:puts(',') end
-            self:puts(' ')
-            self:putValue(t[i])
-            count = count + 1
-         end
+      self.level = self.level + 1
 
-         for i = 1, nonSequentialKeysLength do
-            local k = nonSequentialKeys[i]
-            if count > 0 then self:puts(',') end
-            self:tabify()
-            self:putKey(k)
-            self:puts(' = ')
-            self:putValue(t[k])
-            count = count + 1
-         end
+      local count = 0
+      for i = 1, sequenceLength do
+         if count > 0 then self:puts(',') end
+         self:puts(' ')
+         self:putValue(t[i])
+         count = count + 1
+      end
 
-         if type(mt) == 'table' then
-            if count > 0 then self:puts(',') end
-            self:tabify()
-            self:puts('<metatable> = ')
-            self:putValue(mt)
-         end
-      end)
+      for i = 1, nonSequentialKeysLength do
+         local k = nonSequentialKeys[i]
+         if count > 0 then self:puts(',') end
+         self:tabify()
+         self:putKey(k)
+         self:puts(' = ')
+         self:putValue(t[k])
+         count = count + 1
+      end
+
+      if type(mt) == 'table' then
+         if count > 0 then self:puts(',') end
+         self:tabify()
+         self:puts('<metatable> = ')
+         self:putValue(mt)
+      end
+
+      self.level = self.level - 1
 
       if nonSequentialKeysLength > 0 or type(mt) == 'table' then
          self:tabify()

--- a/inspect.lua
+++ b/inspect.lua
@@ -247,33 +247,29 @@ function Inspector:putValue(v)
          puts('{')
          self.level = self.level + 1
 
-         local count = 0
-         for i = 1, seqLen do
-            if count > 0 then puts(',') end
-            puts(' ')
-            self:putValue(t[i])
-            count = count + 1
-         end
-
-         for i = 1, keysLen do
-            local k = keys[i]
-            if count > 0 then puts(',') end
-            self:tabify()
-            if isIdentifier(k) then
-               puts(k)
+         for i = 1, seqLen + keysLen do
+            if i > 1 then puts(',') end
+            if i <= seqLen then
+               puts(' ')
+               self:putValue(t[i])
             else
-               puts("[")
-               self:putValue(k)
-               puts("]")
+               local k = keys[i - seqLen]
+               self:tabify()
+               if isIdentifier(k) then
+                  puts(k)
+               else
+                  puts("[")
+                  self:putValue(k)
+                  puts("]")
+               end
+               puts(' = ')
+               self:putValue(t[k])
             end
-            puts(' = ')
-            self:putValue(t[k])
-            count = count + 1
          end
 
          local mt = getmetatable(t)
          if type(mt) == 'table' then
-            if count > 0 then puts(',') end
+            if seqLen + keysLen > 0 then puts(',') end
             self:tabify()
             puts('<metatable> = ')
             self:putValue(mt)

--- a/inspect.lua
+++ b/inspect.lua
@@ -240,7 +240,7 @@ function Inspector:putValue(v)
       elseif self.level >= self.depth then
          puts('{...}')
       else
-         if self.refs[t] > 1 then puts('<' .. self:getId(t) .. '>') end
+         if self.refs[t] > 1 then puts(fmt('<%d>', self:getId(t))) end
 
          local keys, keysLen, seqLen = getKeys(t)
 
@@ -287,7 +287,7 @@ function Inspector:putValue(v)
       end
 
    else
-      puts('<' .. tv .. ' ' .. self:getId(v) .. '>')
+      puts(fmt('<%s %d>', tv, self:getId(v)))
    end
 end
 

--- a/inspect.lua
+++ b/inspect.lua
@@ -107,15 +107,11 @@ local function sortKeys(a, b)
       return (a) < (b)
    end
 
-   local dta, dtb = defaultTypeOrders[ta], defaultTypeOrders[tb]
-
-   if dta and dtb then return defaultTypeOrders[ta] < defaultTypeOrders[tb]
-   elseif dta then return true
-   elseif dtb then return false
-   end
+   local dta = defaultTypeOrders[ta] or 100
+   local dtb = defaultTypeOrders[tb] or 100
 
 
-   return ta < tb
+   return dta == dtb and ta < tb or dta < dtb
 end
 
 

--- a/inspect.lua
+++ b/inspect.lua
@@ -48,6 +48,11 @@ inspect.KEY = setmetatable({}, { __tostring = function() return 'inspect.KEY' en
 inspect.METATABLE = setmetatable({}, { __tostring = function() return 'inspect.METATABLE' end })
 
 local tostring = tostring
+local rep = string.rep
+local match = string.match
+local char = string.char
+local gsub = string.gsub
+local fmt = string.format
 
 local function rawpairs(t)
    return next, t, nil
@@ -56,10 +61,10 @@ end
 
 
 local function smartQuote(str)
-   if str:match('"') and not str:match("'") then
+   if match(str, '"') and not match(str, "'") then
       return "'" .. str .. "'"
    end
-   return '"' .. str:gsub('"', '\\"') .. '"'
+   return '"' .. gsub(str, '"', '\\"') .. '"'
 end
 
 
@@ -69,17 +74,17 @@ local shortControlCharEscapes = {
 }
 local longControlCharEscapes = { ["\127"] = "\127" }
 for i = 0, 31 do
-   local ch = string.char(i)
+   local ch = char(i)
    if not shortControlCharEscapes[ch] then
       shortControlCharEscapes[ch] = "\\" .. i
-      longControlCharEscapes[ch] = string.format("\\%03d", i)
+      longControlCharEscapes[ch] = fmt("\\%03d", i)
    end
 end
 
 local function escape(str)
-   return (str:gsub("\\", "\\\\"):
-   gsub("(%c)%f[0-9]", longControlCharEscapes):
-   gsub("%c", shortControlCharEscapes))
+   return (gsub(gsub(gsub(str, "\\", "\\\\"),
+   "(%c)%f[0-9]", longControlCharEscapes),
+   "%c", shortControlCharEscapes))
 end
 
 local function isIdentifier(str)

--- a/inspect.lua
+++ b/inspect.lua
@@ -229,10 +229,6 @@ function Inspector:tabify()
    string.rep(self.indent, self.level))
 end
 
-function Inspector:alreadyVisited(v)
-   return self.ids[v] ~= nil
-end
-
 function Inspector:getId(v)
    local id = self.ids[v]
    local ids = self.ids
@@ -257,8 +253,6 @@ end
 function Inspector:putTable(t)
    if t == inspect.KEY or t == inspect.METATABLE then
       self:puts(tostring(t))
-   elseif self:alreadyVisited(t) then
-      self:puts('<table ', self:getId(t), '>')
    elseif self.level >= self.depth then
       self:puts('{...}')
    else
@@ -314,7 +308,7 @@ function Inspector:putValue(v)
    elseif tv == 'number' or tv == 'boolean' or tv == 'nil' or
       tv == 'cdata' or tv == 'ctype' then
       self:puts(tostring(v))
-   elseif tv == 'table' then
+   elseif tv == 'table' and not self.ids[v] then
       self:putTable(v)
    else
       self:puts('<', tv, ' ', self:getId(v), '>')

--- a/inspect.lua
+++ b/inspect.lua
@@ -216,7 +216,6 @@ local Inspector = {}
 
 
 
-
 local Inspector_mt = { __index = Inspector }
 
 function Inspector:puts(a, b, c, d, e)
@@ -227,12 +226,6 @@ function Inspector:puts(a, b, c, d, e)
    buffer[len + 3] = c
    buffer[len + 4] = d
    buffer[len + 5] = e
-end
-
-function Inspector:down(f)
-   self.level = self.level + 1
-   f()
-   self.level = self.level - 1
 end
 
 function Inspector:tabify()
@@ -246,11 +239,11 @@ end
 
 function Inspector:getId(v)
    local id = self.ids[v]
+   local ids = self.ids
    if not id then
       local tv = type(v)
-      id = (self.maxIds[tv] or 0) + 1
-      self.maxIds[tv] = id
-      self.ids[v] = id
+      id = (ids[tv] or 0) + 1
+      ids[v], ids[tv] = id, id
    end
    return tostring(id)
 end
@@ -352,7 +345,6 @@ function inspect.inspect(root, options)
       level = 0,
       buffer = {},
       ids = {},
-      maxIds = {},
       newline = newline,
       indent = indent,
       tableAppearances = countTableAppearances(root),

--- a/inspect.tl
+++ b/inspect.tl
@@ -143,23 +143,19 @@ local function getNonSequentialKeys(t: table): {any}, integer, integer
    return keys, keysLength, sequenceLength
 end
 
-local function countTableAppearances(t: any, tableAppearances: {any:integer}): {any:integer}
-   tableAppearances = tableAppearances or {}
-
-   if t is table then
-      if not tableAppearances[t] then
-         tableAppearances[t] = 1
-         for k,v in rawpairs(t) do
-            countTableAppearances(k, tableAppearances)
-            countTableAppearances(v, tableAppearances)
+local function countRefs(x: any, refs: {any:integer}): {any:integer}
+   if x is table then
+      if not refs[x] then
+         refs[x] = 1
+         for k,v in rawpairs(x) do
+            countRefs(k, refs)
+            countRefs(v, refs)
          end
-         countTableAppearances(getmetatable(t), tableAppearances)
+         countRefs(getmetatable(x), refs)
       else
-         tableAppearances[t] = tableAppearances[t] + 1
+         refs[x] = refs[x] + 1
       end
    end
-
-   return tableAppearances
 end
 
 local function makePath(path: {any}, a: any, b: any): {any}
@@ -213,7 +209,7 @@ local type Inspector = record
    ids: {any:integer}
    newline: string
    indent: string
-   tableAppearances: {table: integer}
+   refs: {table: integer}
 end
 
 local Inspector_mt = {__index = Inspector}
@@ -266,7 +262,7 @@ function Inspector:putTable(t: table): nil
    elseif self.level >= self.depth then
       self:puts('{...}')
    else
-      if self.tableAppearances[t] > 1 then self:puts('<', self:getId(t), '>') end
+      if self.refs[t] > 1 then self:puts('<', self:getId(t), '>') end
 
       local nonSequentialKeys, nonSequentialKeysLength, sequenceLength = getNonSequentialKeys(t)
       local mt = getmetatable(t)
@@ -340,6 +336,9 @@ function inspect.inspect(root: any, options: inspect.Options): string
       root = processRecursive(process, root, {}, {})
    end
 
+   local refs = {}
+   countRefs(root, refs)
+
    local inspector = setmetatable({
       depth            = depth,
       level            = 0,
@@ -347,7 +346,7 @@ function inspect.inspect(root: any, options: inspect.Options): string
       ids              = {},
       newline          = newline,
       indent           = indent,
-      tableAppearances = countTableAppearances(root)
+      refs             = refs,
    } as Inspector, Inspector_mt)
 
    inspector:putValue(root)

--- a/inspect.tl
+++ b/inspect.tl
@@ -48,6 +48,11 @@ inspect.KEY       = setmetatable({}, {__tostring = function(): string return 'in
 inspect.METATABLE = setmetatable({}, {__tostring = function(): string return 'inspect.METATABLE' end})
 
 local tostring = tostring
+local rep = string.rep
+local match = string.match
+local char = string.char
+local gsub = string.gsub
+local fmt = string.format
 
 local function rawpairs(t: table): function, table, nil
    return next, t, nil
@@ -56,10 +61,10 @@ end
 -- Apostrophizes the string if it has quotes, but not aphostrophes
 -- Otherwise, it returns a regular quoted string
 local function smartQuote(str: string): string
-   if str:match('"') and not str:match("'") then
+   if match(str, '"') and not match(str, "'") then
       return "'" .. str .. "'"
    end
-   return '"' .. str:gsub('"', '\\"') .. '"'
+   return '"' .. gsub(str, '"', '\\"') .. '"'
 end
 
 -- \a => '\\a', \0 => '\\0', 31 => '\31'
@@ -69,17 +74,17 @@ local shortControlCharEscapes: {string:string} = {
 }
 local longControlCharEscapes: {string:string} = {["\127"]="\127"} -- \a => nil, \0 => \000, 31 => \031
 for i=0, 31 do
-   local ch: string = string.char(i)
+   local ch: string = char(i)
    if not shortControlCharEscapes[ch] then
       shortControlCharEscapes[ch] = "\\"..i
-      longControlCharEscapes[ch]  = string.format("\\%03d", i)
+      longControlCharEscapes[ch]  = fmt("\\%03d", i)
    end
 end
 
 local function escape(str: string): string
-   return (str:gsub("\\", "\\\\")
-              :gsub("(%c)%f[0-9]", longControlCharEscapes)
-              :gsub("%c", shortControlCharEscapes))
+   return (gsub(gsub(gsub(str,"\\", "\\\\"),
+      "(%c)%f[0-9]", longControlCharEscapes),
+      "%c", shortControlCharEscapes))
 end
 
 local function isIdentifier(str: any): boolean

--- a/inspect.tl
+++ b/inspect.tl
@@ -229,10 +229,6 @@ function Inspector:tabify(): nil
    string.rep(self.indent, self.level))
 end
 
-function Inspector:alreadyVisited(v: any): boolean
-   return self.ids[v] ~= nil
-end
-
 function Inspector:getId(v: any): string
    local id: integer = self.ids[v]
    local ids = self.ids
@@ -257,8 +253,6 @@ end
 function Inspector:putTable(t: table): nil
    if t == inspect.KEY or t == inspect.METATABLE then
       self:puts(tostring(t))
-   elseif self:alreadyVisited(t) then
-      self:puts('<table ', self:getId(t), '>')
    elseif self.level >= self.depth then
       self:puts('{...}')
    else
@@ -314,7 +308,7 @@ function Inspector:putValue(v: any)
    elseif tv == 'number' or tv == 'boolean' or tv == 'nil' or
           tv == 'cdata' or tv == 'ctype' then
       self:puts(tostring(v as number))
-   elseif tv == 'table' then
+   elseif tv == 'table' and not self.ids[v] then
       self:putTable(v as table)
    else
       self:puts('<', tv, ' ', self:getId(v), '>')

--- a/inspect.tl
+++ b/inspect.tl
@@ -114,29 +114,23 @@ local function sortKeys(a:any, b:any): boolean
    return dta == dtb and ta < tb or dta < dtb
 end
 
--- For implementation reasons, the behavior of rawlen & # is "undefined" when
--- tables aren't pure sequences. So we implement our own # operator.
-local function getSequenceLength(t: table): integer
-   local len: integer = 1
-   local v: any = rawget(t, len)
-   while v ~= nil do
-      len = len + 1
-      v = rawget(t,len)
+local function getKeys(t: table): {any}, integer, integer
+   -- seqLen counts the "array-like" keys
+   local seqLen: integer = 1
+   while rawget(t, seqLen) ~= nil do
+     seqLen = seqLen + 1
    end
-   return len - 1
-end
+   seqLen = seqLen - 1
 
-local function getNonSequentialKeys(t: table): {any}, integer, integer
-   local keys, keysLength: {any}, integer = {}, 0
-   local sequenceLength: integer = getSequenceLength(t)
-   for k,_ in rawpairs(t) do
-      if not isSequenceKey(k, sequenceLength) then
-         keysLength = keysLength + 1
-         keys[keysLength] = k
+   local keys, keysLen: {any}, integer = {}, 0
+   for k in rawpairs(t) do
+      if not isSequenceKey(k, seqLen) then
+         keysLen = keysLen + 1
+         keys[keysLen] = k
       end
    end
    table.sort(keys, sortKeys)
-   return keys, keysLength, sequenceLength
+   return keys, keysLen, seqLen
 end
 
 local function countRefs(x: any, refs: {any:integer}): {any:integer}
@@ -222,7 +216,7 @@ end
 
 function Inspector:tabify(): nil
    self:puts(self.newline,
-   string.rep(self.indent, self.level))
+     string.rep(self.indent, self.level))
 end
 
 function Inspector:getId(v: any): string
@@ -254,8 +248,7 @@ function Inspector:putTable(t: table): nil
    else
       if self.refs[t] > 1 then self:puts('<', self:getId(t), '>') end
 
-      local nonSequentialKeys, nonSequentialKeysLength, sequenceLength = getNonSequentialKeys(t)
-      local mt = getmetatable(t)
+         local keys, keysLen, seqLen = getKeys(t)
 
       self:puts('{')
       self.level = self.level + 1

--- a/inspect.tl
+++ b/inspect.tl
@@ -240,7 +240,7 @@ function Inspector:putValue(v: any)
       elseif self.level >= self.depth then
          puts('{...}')
       else
-         if self.refs[t] > 1 then puts('<' .. self:getId(t) .. '>') end
+         if self.refs[t] > 1 then puts(fmt('<%d>', self:getId(t))) end
 
          local keys, keysLen, seqLen = getKeys(t)
 
@@ -287,7 +287,7 @@ function Inspector:putValue(v: any)
        end
 
    else
-      puts('<' .. tv .. ' ' .. self:getId(v) .. '>')
+      puts(fmt('<%s %d>', tv, self:getId(v)))
    end
 end
 

--- a/inspect.tl
+++ b/inspect.tl
@@ -230,66 +230,6 @@ function Inspector:getId(v: any): string
    return tostring(id)
 end
 
-function Inspector:putKey(k: any): nil
-   if isIdentifier(k) then
-      self:puts(k as string)
-      return
-   end
-   self:puts("[")
-   self:putValue(k)
-   self:puts("]")
-end
-
-function Inspector:putTable(t: table): nil
-   if t == inspect.KEY or t == inspect.METATABLE then
-      self:puts(tostring(t))
-   elseif self.level >= self.depth then
-      self:puts('{...}')
-   else
-      if self.refs[t] > 1 then self:puts('<', self:getId(t), '>') end
-
-         local keys, keysLen, seqLen = getKeys(t)
-
-      self:puts('{')
-      self.level = self.level + 1
-
-      local count = 0
-      for i=1, sequenceLength do
-        if count > 0 then self:puts(',') end
-        self:puts(' ')
-        self:putValue(t[i])
-        count = count + 1
-      end
-
-      for i=1, nonSequentialKeysLength do
-        local k = nonSequentialKeys[i]
-        if count > 0 then self:puts(',') end
-        self:tabify()
-        self:putKey(k)
-        self:puts(' = ')
-        self:putValue(t[k])
-        count = count + 1
-      end
-
-      if type(mt) == 'table' then
-        if count > 0 then self:puts(',') end
-        self:tabify()
-        self:puts('<metatable> = ')
-        self:putValue(mt)
-      end
-
-      self.level = self.level - 1
-
-      if nonSequentialKeysLength > 0 or type(mt) == 'table' then -- result is multi-lined. Justify closing }
-         self:tabify()
-      elseif sequenceLength > 0 then -- array tables have one extra space before closing }
-         self:puts(' ')
-      end
-
-      self:puts('}')
-   end
-end
-
 function Inspector:putValue(v: any)
    local tv: string = type(v)
    if tv == 'string' then
@@ -298,7 +238,63 @@ function Inspector:putValue(v: any)
           tv == 'cdata' or tv == 'ctype' then
       self:puts(tostring(v as number))
    elseif tv == 'table' and not self.ids[v] then
-      self:putTable(v as table)
+      local t = v as table
+
+      if t == inspect.KEY or t == inspect.METATABLE then
+         self:puts(tostring(t))
+      elseif self.level >= self.depth then
+         self:puts('{...}')
+      else
+         if self.refs[t] > 1 then self:puts('<', self:getId(t), '>') end
+
+         local keys, keysLen, seqLen = getKeys(t)
+
+         self:puts('{')
+         self.level = self.level + 1
+
+         local count = 0
+         for i=1, seqLen do
+           if count > 0 then self:puts(',') end
+           self:puts(' ')
+           self:putValue(t[i])
+           count = count + 1
+         end
+
+         for i = 1, keysLen do
+           local k = keys[i]
+           if count > 0 then self:puts(',') end
+           self:tabify()
+           if isIdentifier(k) then
+             self:puts(k as string)
+           else
+             self:puts("[")
+             self:putValue(k)
+             self:puts("]")
+           end
+           self:puts(' = ')
+           self:putValue(t[k])
+           count = count + 1
+         end
+
+         local mt = getmetatable(t)
+         if type(mt) == 'table' then
+           if count > 0 then self:puts(',') end
+           self:tabify()
+           self:puts('<metatable> = ')
+           self:putValue(mt)
+         end
+
+         self.level = self.level - 1
+
+         if keysLen > 0 or type(mt) == 'table' then -- result is multi-lined. Justify closing }
+           self:tabify()
+         elseif seqLen > 0 then -- array tables have one extra space before closing }
+           self:puts(' ')
+         end
+
+         self:puts('}')
+       end
+
    else
       self:puts('<', tv, ' ', self:getId(v), '>')
    end

--- a/inspect.tl
+++ b/inspect.tl
@@ -211,7 +211,6 @@ local type Inspector = record
    level: integer
    buffer: {string}
    ids: {any:integer}
-   maxIds: {any:integer}
    newline: string
    indent: string
    tableAppearances: {table: integer}
@@ -229,12 +228,6 @@ function Inspector:puts(a:string, b:string, c:string, d:string, e:string): nil
    buffer[len+5] = e
 end
 
-function Inspector:down(f: function()): nil
-   self.level = self.level + 1
-   f()
-   self.level = self.level - 1
-end
-
 function Inspector:tabify(): nil
    self:puts(self.newline,
    string.rep(self.indent, self.level))
@@ -246,11 +239,11 @@ end
 
 function Inspector:getId(v: any): string
    local id: integer = self.ids[v]
+   local ids = self.ids
    if not id then
       local tv: string = type(v)
-      id              = (self.maxIds[tv] or 0) + 1
-      self.maxIds[tv] = id
-      self.ids[v]     = id
+      id = (ids[tv] or 0) + 1
+      ids[v], ids[tv] = id, id
    end
    return tostring(id)
 end
@@ -352,7 +345,6 @@ function inspect.inspect(root: any, options: inspect.Options): string
       level            = 0,
       buffer           = {},
       ids              = {},
-      maxIds           = {},
       newline          = newline,
       indent           = indent,
       tableAppearances = countTableAppearances(root)

--- a/inspect.tl
+++ b/inspect.tl
@@ -107,15 +107,11 @@ local function sortKeys(a:any, b:any): boolean
       return (a as string) < (b as string)
    end
 
-   local dta, dtb: integer, integer = defaultTypeOrders[ta], defaultTypeOrders[tb]
-   -- Two default types are compared according to the defaultTypeOrders table
-   if dta and dtb then return defaultTypeOrders[ta] < defaultTypeOrders[tb]
-   elseif dta     then return true  -- default types before custom ones
-   elseif dtb     then return false -- custom types after default ones
-   end
-
-   -- custom types are sorted out alphabetically
-   return ta < tb
+   local dta: integer = defaultTypeOrders[ta] or 100
+   local dtb: integer = defaultTypeOrders[tb] or 100
+   -- Default types are compared according to defaultTypeOrders
+   -- Custom types are compared alphabetically
+   return dta == dtb and ta < tb or dta < dtb
 end
 
 -- For implementation reasons, the behavior of rawlen & # is "undefined" when

--- a/inspect.tl
+++ b/inspect.tl
@@ -255,10 +255,6 @@ function Inspector:getId(v: any): string
    return tostring(id)
 end
 
--- dummy function; defined later
-function Inspector:putValue(_: any):nil
-end
-
 function Inspector:putKey(k: any): nil
    if isIdentifier(k) then
       self:puts(k as string)

--- a/inspect.tl
+++ b/inspect.tl
@@ -138,17 +138,17 @@ local function getKeys(t: table): {any}, integer, integer
    return keys, keysLen, seqLen
 end
 
-local function countRefs(x: any, refs: {any:integer}): {any:integer}
+local function countCycles(x: any, cycles: {any:integer}): nil
    if x is table then
-      if not refs[x] then
-         refs[x] = 1
-         for k,v in rawpairs(x) do
-            countRefs(k, refs)
-            countRefs(v, refs)
-         end
-         countRefs(getmetatable(x), refs)
+      if cycles[x] then
+         cycles[x] = cycles[x] + 1
       else
-         refs[x] = refs[x] + 1
+         cycles[x] = 1
+         for k,v in rawpairs(x) do
+            countCycles(k, cycles)
+            countCycles(v, cycles)
+         end
+         countCycles(getmetatable(x), cycles)
       end
    end
 end
@@ -207,7 +207,7 @@ local type Inspector = record
    ids: {any:integer}
    newline: string
    indent: string
-   refs: {table: integer}
+   cycles: {table: integer}
    puts: function(string)
 end
 
@@ -244,7 +244,7 @@ function Inspector:putValue(v: any)
       elseif self.level >= self.depth then
          puts(buf, '{...}')
       else
-         if self.refs[t] > 1 then puts(buf, fmt('<%d>', self:getId(t))) end
+         if self.cycles[t] > 1 then puts(buf, fmt('<%d>', self:getId(t))) end
 
          local keys, keysLen, seqLen = getKeys(t)
 
@@ -310,17 +310,17 @@ function inspect.inspect(root: any, options: inspect.Options): string
       root = processRecursive(process, root, {}, {})
    end
 
-   local refs = {}
-   countRefs(root, refs)
+   local cycles = {}
+   countCycles(root, cycles)
 
    local inspector = setmetatable({
       buf              = { n = 0 },
+      ids              = {},
+      cycles           = cycles,
       depth            = depth,
       level            = 0,
-      ids              = {},
       newline          = newline,
       indent           = indent,
-      refs             = refs,
    } as Inspector, Inspector_mt)
 
    inspector:putValue(root)

--- a/inspect.tl
+++ b/inspect.tl
@@ -193,11 +193,15 @@ local function processRecursive(process: inspect.ProcessFunction,
    return processed
 end
 
-
+local function puts(buf: table, str:string): nil
+   buf.n = buf.n as integer + 1
+   buf[buf.n as integer] = str
+end
 
 -------------------------------------------------------------------
 
 local type Inspector = record
+   buf: table
    depth: integer
    level: integer
    ids: {any:integer}
@@ -209,8 +213,8 @@ end
 
 local Inspector_mt = {__index = Inspector}
 
-function Inspector:tabify(): nil
-   self.puts(self.newline .. rep(self.indent, self.level))
+local function tabify(inspector: Inspector)
+   puts(inspector.buf, inspector.newline .. rep(inspector.indent, inspector.level))
 end
 
 function Inspector:getId(v: any): string
@@ -225,69 +229,69 @@ function Inspector:getId(v: any): string
 end
 
 function Inspector:putValue(v: any)
-   local puts = self.puts
+   local buf = self.buf
    local tv: string = type(v)
    if tv == 'string' then
-      puts(smartQuote(escape(v as string)))
+      puts(buf, smartQuote(escape(v as string)))
    elseif tv == 'number' or tv == 'boolean' or tv == 'nil' or
           tv == 'cdata' or tv == 'ctype' then
-      puts(tostring(v as number))
+      puts(buf, tostring(v as number))
    elseif tv == 'table' and not self.ids[v] then
       local t = v as table
 
       if t == inspect.KEY or t == inspect.METATABLE then
-         puts(tostring(t))
+         puts(buf, tostring(t))
       elseif self.level >= self.depth then
-         puts('{...}')
+         puts(buf, '{...}')
       else
-         if self.refs[t] > 1 then puts(fmt('<%d>', self:getId(t))) end
+         if self.refs[t] > 1 then puts(buf, fmt('<%d>', self:getId(t))) end
 
          local keys, keysLen, seqLen = getKeys(t)
 
-         puts('{')
+         puts(buf, '{')
          self.level = self.level + 1
 
          for i = 1, seqLen + keysLen do
-            if i > 1 then puts(',') end
+            if i > 1 then puts(buf, ',') end
             if i <= seqLen then
-               puts(' ')
+               puts(buf, ' ')
                self:putValue(t[i])
             else
                local k = keys[i - seqLen]
-               self:tabify()
+               tabify(self)
                if isIdentifier(k) then
-                 puts(k as string)
+                 puts(buf, k as string)
                else
-                 puts("[")
+                 puts(buf, "[")
                  self:putValue(k)
-                 puts("]")
+                 puts(buf, "]")
                end
-               puts(' = ')
+               puts(buf, ' = ')
                self:putValue(t[k])
             end
          end
 
          local mt = getmetatable(t)
          if type(mt) == 'table' then
-           if seqLen + keysLen > 0 then puts(',') end
-           self:tabify()
-           puts('<metatable> = ')
+           if seqLen + keysLen > 0 then puts(buf, ',') end
+           tabify(self)
+           puts(buf, '<metatable> = ')
            self:putValue(mt)
          end
 
          self.level = self.level - 1
 
          if keysLen > 0 or type(mt) == 'table' then -- result is multi-lined. Justify closing }
-           self:tabify()
+           tabify(self)
          elseif seqLen > 0 then -- array tables have one extra space before closing }
-           puts(' ')
+           puts(buf, ' ')
          end
 
-         puts('}')
+         puts(buf, '}')
        end
 
    else
-      puts(fmt('<%s %d>', tv, self:getId(v)))
+      puts(buf, fmt('<%s %d>', tv, self:getId(v)))
    end
 end
 
@@ -309,17 +313,10 @@ function inspect.inspect(root: any, options: inspect.Options): string
    local refs = {}
    countRefs(root, refs)
 
-   local buf: {string} = {}
-   local blen: integer = 0
-   local puts = function(str: string)
-     blen = blen + 1
-     buf[blen] = str
-   end
-
    local inspector = setmetatable({
+      buf              = { n = 0 },
       depth            = depth,
       level            = 0,
-      puts             = puts,
       ids              = {},
       newline          = newline,
       indent           = indent,
@@ -328,7 +325,7 @@ function inspect.inspect(root: any, options: inspect.Options): string
 
    inspector:putValue(root)
 
-   return table.concat(buf)
+   return table.concat(inspector.buf as {string})
 end
 
 setmetatable(inspect, {

--- a/inspect.tl
+++ b/inspect.tl
@@ -200,28 +200,17 @@ end
 local type Inspector = record
    depth: integer
    level: integer
-   buffer: {string}
    ids: {any:integer}
    newline: string
    indent: string
    refs: {table: integer}
+   puts: function(string)
 end
 
 local Inspector_mt = {__index = Inspector}
 
-function Inspector:puts(a:string, b:string, c:string, d:string, e:string): nil
-   local buffer: {string} = self.buffer
-   local len: integer     = #buffer
-   buffer[len+1] = a
-   buffer[len+2] = b
-   buffer[len+3] = c
-   buffer[len+4] = d
-   buffer[len+5] = e
-end
-
 function Inspector:tabify(): nil
-   self:puts(self.newline,
-     string.rep(self.indent, self.level))
+   self.puts(self.newline .. rep(self.indent, self.level))
 end
 
 function Inspector:getId(v: any): string
@@ -236,56 +225,57 @@ function Inspector:getId(v: any): string
 end
 
 function Inspector:putValue(v: any)
+   local puts = self.puts
    local tv: string = type(v)
    if tv == 'string' then
-      self:puts(smartQuote(escape(v as string)))
+      puts(smartQuote(escape(v as string)))
    elseif tv == 'number' or tv == 'boolean' or tv == 'nil' or
           tv == 'cdata' or tv == 'ctype' then
-      self:puts(tostring(v as number))
+      puts(tostring(v as number))
    elseif tv == 'table' and not self.ids[v] then
       local t = v as table
 
       if t == inspect.KEY or t == inspect.METATABLE then
-         self:puts(tostring(t))
+         puts(tostring(t))
       elseif self.level >= self.depth then
-         self:puts('{...}')
+         puts('{...}')
       else
-         if self.refs[t] > 1 then self:puts('<', self:getId(t), '>') end
+         if self.refs[t] > 1 then puts('<' .. self:getId(t) .. '>') end
 
          local keys, keysLen, seqLen = getKeys(t)
 
-         self:puts('{')
+         puts('{')
          self.level = self.level + 1
 
          local count = 0
          for i=1, seqLen do
-           if count > 0 then self:puts(',') end
-           self:puts(' ')
+           if count > 0 then puts(',') end
+           puts(' ')
            self:putValue(t[i])
            count = count + 1
          end
 
          for i = 1, keysLen do
            local k = keys[i]
-           if count > 0 then self:puts(',') end
+           if count > 0 then puts(',') end
            self:tabify()
            if isIdentifier(k) then
-             self:puts(k as string)
+             puts(k as string)
            else
-             self:puts("[")
+             puts("[")
              self:putValue(k)
-             self:puts("]")
+             puts("]")
            end
-           self:puts(' = ')
+           puts(' = ')
            self:putValue(t[k])
            count = count + 1
          end
 
          local mt = getmetatable(t)
          if type(mt) == 'table' then
-           if count > 0 then self:puts(',') end
+           if count > 0 then puts(',') end
            self:tabify()
-           self:puts('<metatable> = ')
+           puts('<metatable> = ')
            self:putValue(mt)
          end
 
@@ -294,14 +284,14 @@ function Inspector:putValue(v: any)
          if keysLen > 0 or type(mt) == 'table' then -- result is multi-lined. Justify closing }
            self:tabify()
          elseif seqLen > 0 then -- array tables have one extra space before closing }
-           self:puts(' ')
+           puts(' ')
          end
 
-         self:puts('}')
+         puts('}')
        end
 
    else
-      self:puts('<', tv, ' ', self:getId(v), '>')
+      puts('<' .. tv .. ' ' .. self:getId(v) .. '>')
    end
 end
 
@@ -323,10 +313,17 @@ function inspect.inspect(root: any, options: inspect.Options): string
    local refs = {}
    countRefs(root, refs)
 
+   local buf: {string} = {}
+   local blen: integer = 0
+   local puts = function(str: string)
+     blen = blen + 1
+     buf[blen] = str
+   end
+
    local inspector = setmetatable({
       depth            = depth,
       level            = 0,
-      buffer           = {},
+      puts             = puts,
       ids              = {},
       newline          = newline,
       indent           = indent,
@@ -335,7 +332,7 @@ function inspect.inspect(root: any, options: inspect.Options): string
 
    inspector:putValue(root)
 
-   return table.concat(inspector.buffer)
+   return table.concat(buf)
 end
 
 setmetatable(inspect, {

--- a/inspect.tl
+++ b/inspect.tl
@@ -279,32 +279,34 @@ function Inspector:putTable(t: table): nil
       local mt = getmetatable(t)
 
       self:puts('{')
-      self:down(function()
-         local count = 0
-         for i=1, sequenceLength do
-            if count > 0 then self:puts(',') end
-            self:puts(' ')
-            self:putValue(t[i])
-            count = count + 1
-         end
+      self.level = self.level + 1
 
-         for i=1, nonSequentialKeysLength do
-            local k = nonSequentialKeys[i]
-            if count > 0 then self:puts(',') end
-            self:tabify()
-            self:putKey(k)
-            self:puts(' = ')
-            self:putValue(t[k])
-            count = count + 1
-         end
+      local count = 0
+      for i=1, sequenceLength do
+        if count > 0 then self:puts(',') end
+        self:puts(' ')
+        self:putValue(t[i])
+        count = count + 1
+      end
 
-         if type(mt) == 'table' then
-            if count > 0 then self:puts(',') end
-            self:tabify()
-            self:puts('<metatable> = ')
-            self:putValue(mt)
-         end
-      end)
+      for i=1, nonSequentialKeysLength do
+        local k = nonSequentialKeys[i]
+        if count > 0 then self:puts(',') end
+        self:tabify()
+        self:putKey(k)
+        self:puts(' = ')
+        self:putValue(t[k])
+        count = count + 1
+      end
+
+      if type(mt) == 'table' then
+        if count > 0 then self:puts(',') end
+        self:tabify()
+        self:puts('<metatable> = ')
+        self:putValue(mt)
+      end
+
+      self.level = self.level - 1
 
       if nonSequentialKeysLength > 0 or type(mt) == 'table' then -- result is multi-lined. Justify closing }
          self:tabify()

--- a/inspect.tl
+++ b/inspect.tl
@@ -247,33 +247,29 @@ function Inspector:putValue(v: any)
          puts('{')
          self.level = self.level + 1
 
-         local count = 0
-         for i=1, seqLen do
-           if count > 0 then puts(',') end
-           puts(' ')
-           self:putValue(t[i])
-           count = count + 1
-         end
-
-         for i = 1, keysLen do
-           local k = keys[i]
-           if count > 0 then puts(',') end
-           self:tabify()
-           if isIdentifier(k) then
-             puts(k as string)
-           else
-             puts("[")
-             self:putValue(k)
-             puts("]")
-           end
-           puts(' = ')
-           self:putValue(t[k])
-           count = count + 1
+         for i = 1, seqLen + keysLen do
+            if i > 1 then puts(',') end
+            if i <= seqLen then
+               puts(' ')
+               self:putValue(t[i])
+            else
+               local k = keys[i - seqLen]
+               self:tabify()
+               if isIdentifier(k) then
+                 puts(k as string)
+               else
+                 puts("[")
+                 self:putValue(k)
+                 puts("]")
+               end
+               puts(' = ')
+               self:putValue(t[k])
+            end
          end
 
          local mt = getmetatable(t)
          if type(mt) == 'table' then
-           if count > 0 then puts(',') end
+           if seqLen + keysLen > 0 then puts(',') end
            self:tabify()
            puts('<metatable> = ')
            self:putValue(mt)

--- a/perf.lua
+++ b/perf.lua
@@ -1,0 +1,112 @@
+local inspect = require 'inspect'
+
+local skip_headers = ...
+
+local N=100000
+
+local results = {}
+
+local time = function(name, n, f)
+  local clock = os.clock
+
+  collectgarbage()
+  collectgarbage()
+  collectgarbage()
+
+  local startTime = clock()
+
+  for i=0,n do f() end
+
+  local duration = clock() - startTime
+
+  results[#results + 1] = { name, duration }
+end
+
+-------------------
+
+time('nil', N, function()
+  inspect(nil)
+end)
+
+time('string', N, function()
+  inspect("hello")
+end)
+
+local e={}
+time('empty', N, function()
+  inspect(e)
+end)
+
+local seq={1,2,3,4}
+time('sequence', N, function()
+  inspect(seq)
+end)
+
+local record={a=1, b=2, c=3}
+time('record', N, function()
+  inspect(record)
+end)
+
+local hybrid={1, 2, 3, a=1, b=2, c=3}
+time('hybrid', N, function()
+  inspect(hybrid)
+end)
+
+local recursive = {}
+recursive.x = recursive
+time('recursive', N, function()
+  inspect(recursive)
+end)
+
+local with_meta=setmetatable({},
+  { __tostring = function() return "s" end })
+time('meta', N, function()
+  inspect(with_meta)
+end)
+
+local process_options = {
+  process = function(i,p) return "p" end
+}
+time('process', N, function()
+  inspect(seq, process_options)
+end)
+
+local complex = {
+  a = 1,
+  true,
+  print,
+  [print] = print,
+  [{}] = { {}, 3, b = {x = 42} }
+}
+complex.x = complex
+setmetatable(complex, complex)
+time('complex', N, function()
+  inspect(complex)
+end)
+
+local big = {}
+for i = 1,1000 do
+  big[i] = i
+end
+for i = 1,1000 do
+  big["a" .. i] = 1
+end
+time('big', N/100, function()
+  inspect(big)
+end)
+
+------
+
+if not skip_headers then
+  for i,r in ipairs(results) do
+    if i > 1 then io.write(",") end
+    io.write(r[1])
+  end
+  io.write("\n")
+end
+
+for i,r in ipairs(results) do
+  if i > 1 then io.write(",") end
+  io.write(r[2])
+end
+io.write("\n")


### PR DESCRIPTION
- (perf) add simple perf test harness
- (refactor) remove unnecessary forward-declaration
- (refactor) remove self:down function
- (refactor) remove maxIds
- (refactor) rename tableAppearances to refs
- (refactor) remove alreadyVisited. Use exit condition for table refs
- (refactor) sortkeys compare function
- (refactor) simplify getNonSequentialKeys, rename to getKeys
- (refactor) combine putKey, putValue and putTable into a single method
- (refactor) localize common functions
- (refactor) replace puts method by a one-time build function
- (refactor) single loop for both kinds of keys
- (perf) replace some concatenations with string.format
- (refactor) undo localized puts function
- (refactor) rename refs to cycles
